### PR TITLE
Simplify/improve animation of remaining words on successful guess

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -10,9 +10,9 @@ export type WordGroup = {
 };
 
 const Game = ({ gameData }: { gameData: GameData }) => {
-  const [orderedWords, setOrderedWords] = useState(gameData.words);
+  const [remainingWords, setRemainingWords] = useState(gameData.words);
   const shuffleWords = () => {
-    setOrderedWords(shuffle(orderedWords));
+    setRemainingWords(shuffle(remainingWords));
   };
 
   // used to prevent double submission
@@ -44,10 +44,6 @@ const Game = ({ gameData }: { gameData: GameData }) => {
   solvedGroupData.forEach(({ words }) => {
     solvedWords = solvedWords.concat(words);
   });
-  // all the words not contained in solved groups
-  const remainingWords = orderedWords.filter(
-    (word) => !solvedWords.includes(word),
-  );
 
   // how many tries the user still has to guess
   const [mistakesLeft, setMistakesLeft] = useState(4);
@@ -90,6 +86,8 @@ const Game = ({ gameData }: { gameData: GameData }) => {
               <button
                 disabled={submitLocked || selected.length < 4}
                 onClick={() => {
+                  // do the selected words match a word group?
+                  // todo: minor improvement ~ skip already correct groups
                   const matchedGroup = gameData.groups.find(({ words }) =>
                     words.every((word) => selected.includes(word)),
                   );
@@ -99,6 +97,10 @@ const Game = ({ gameData }: { gameData: GameData }) => {
                       ...solvedGroups,
                       matchedGroup.description,
                     ]);
+                    // remove these words from the remaining words
+                    const newRemainingWords = remainingWords.filter(
+                      (word) => !matchedGroup.words.includes(word),
+                    );
                   } else {
                     setSubmitLocked(true);
                     setMistakesLeft((n) => n - 1);

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -102,15 +102,18 @@ const Game = ({ gameData }: { gameData: GameData }) => {
                     //   This results in a slick-minimal animation of only the top words moving down.
                     // First get the remaining top row words
                     const topRowWords = remainingWords
-                      .slice(0, 4)
+                      .slice(0, 4) // take the first four
                       .filter((word) => !matchedGroup.words.includes(word));
                     // Now take the bottom words and use map to...
-                    const bottomWords = remainingWords.slice(4).map((word) => {
-                      // Replace words that are being removed with top row words
-                      if (matchedGroup.words.includes(word)) {
-                        return topRowWords.shift()!;
-                      } else return word; // do nothing to other words
-                    });
+                    const bottomWords = remainingWords
+                      .slice(4) // skip the first four
+                      .map((word) => {
+                        if (matchedGroup.words.includes(word)) {
+                          return topRowWords.shift()!; // replace with word from the top
+                        } else {
+                          return word; // do nothing to other words
+                        }
+                      });
 
                     setRemainingWords(bottomWords);
                   } else {

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -97,10 +97,22 @@ const Game = ({ gameData }: { gameData: GameData }) => {
                       ...solvedGroups,
                       matchedGroup.description,
                     ]);
-                    // remove these words from the remaining words
-                    const newRemainingWords = remainingWords.filter(
-                      (word) => !matchedGroup.words.includes(word),
-                    );
+
+                    // Re-order the remaining words on the top row into the spots made vacant by the selected words.
+                    //   This results in a slick-minimal animation of only the top words moving down.
+                    // First get the remaining top row words
+                    const topRowWords = remainingWords
+                      .slice(0, 4)
+                      .filter((word) => !matchedGroup.words.includes(word));
+                    // Now take the bottom words and use map to...
+                    const bottomWords = remainingWords.slice(4).map((word) => {
+                      // Replace words that are being removed with top row words
+                      if (matchedGroup.words.includes(word)) {
+                        return topRowWords.shift()!;
+                      } else return word; // do nothing to other words
+                    });
+
+                    setRemainingWords(bottomWords);
                   } else {
                     setSubmitLocked(true);
                     setMistakesLeft((n) => n - 1);


### PR DESCRIPTION
This minimizes and improves the animated "movement" that happens when getting a successful guess. Previously all items would move. With this change the remaining unguessed items on the top row move into the spots made vacant by guessed items. This is what happens on the NYT game. 

Note that the NYT game also animates the guess items up towards the top, which this does not do.